### PR TITLE
Fixed some issues when rendering Event/{id} page from different parts…

### DIFF
--- a/routes/events.js
+++ b/routes/events.js
@@ -9,6 +9,7 @@ const xss=require('xss');
 
 router.get('/', async (req, res) => {
     let allTags = await allEvents.get_all_tags();
+    req.session.prevURL = '/events';
     if (xss(req.session.userId)) {
         try{
             let eventList=await allEvents.get_all_upcoming_events();
@@ -144,12 +145,30 @@ router.get('/:id', async (req, res) => {
         const currentDate = new Date();
         const eventDate = new Date(event.date);
         if (eventDate < currentDate) {
-            res.render('shows/event', {title: event.name, user_id: req.session.userId, event_name: event.name, event_id: event._id.toString(), event_creator: event_creator_name, event_date: event.date, event_time: event.time, event_location: event.location, event_description: event.description, event_tags: event.tags, event_comments: comments_list, eventPassed: true, numAttending: event.users_registered.length});
+            if (req.session.prevURL == '/user') {
+                res.render('shows/event', {title: event.name, user_id: req.session.userId, event_name: event.name, event_id: event._id.toString(), event_creator: event_creator_name, event_date: event.date, event_time: event.time, event_location: event.location, event_description: event.description, event_tags: event.tags, event_comments: comments_list, eventPassed: true, numAttending: event.users_registered.length});
+            } else if (req.session.prevURL == '/user/regEvents') {
+                res.render('shows/event', {title: event.name, user_id: req.session.userId, event_name: event.name, event_id: event._id.toString(), event_creator: event_creator_name, event_date: event.date, event_time: event.time, event_location: event.location, event_description: event.description, event_tags: event.tags, event_comments: comments_list, eventPassed: true, numAttending: event.users_registered.length, myReg: true});
+            } else {
+                res.render('shows/event', {title: event.name, user_id: req.session.userId, event_name: event.name, event_id: event._id.toString(), event_creator: event_creator_name, event_date: event.date, event_time: event.time, event_location: event.location, event_description: event.description, event_tags: event.tags, event_comments: comments_list, eventPassed: true, numAttending: event.users_registered.length, home: true});
+            }
         } else {
             if (event.users_registered.includes(req.session.userId)) {
-                res.render('shows/event', {title: event.name, user_id: req.session.userId, event_name: event.name, event_id: event._id.toString(), event_creator: event_creator_name, event_date: event.date, event_time: event.time, event_location: event.location, event_description: event.description, event_tags: event.tags, event_comments: comments_list, alreadyRegistered: true, numAttending: event.users_registered.length});
+                if (req.session.prevURL == '/user') {
+                    res.render('shows/event', {title: event.name, user_id: req.session.userId, event_name: event.name, event_id: event._id.toString(), event_creator: event_creator_name, event_date: event.date, event_time: event.time, event_location: event.location, event_description: event.description, event_tags: event.tags, event_comments: comments_list, alreadyRegistered: true, numAttending: event.users_registered.length});
+                } else if (req.session.prevURL == '/user/regEvents') {
+                    res.render('shows/event', {title: event.name, user_id: req.session.userId, event_name: event.name, event_id: event._id.toString(), event_creator: event_creator_name, event_date: event.date, event_time: event.time, event_location: event.location, event_description: event.description, event_tags: event.tags, event_comments: comments_list, alreadyRegistered: true, numAttending: event.users_registered.length, myReg: true});
+                } else {
+                    res.render('shows/event', {title: event.name, user_id: req.session.userId, event_name: event.name, event_id: event._id.toString(), event_creator: event_creator_name, event_date: event.date, event_time: event.time, event_location: event.location, event_description: event.description, event_tags: event.tags, event_comments: comments_list, alreadyRegistered: true, numAttending: event.users_registered.length, home: true});
+                }
             } else {
-                res.render('shows/event', {title: event.name, user_id: req.session.userId, event_name: event.name, event_id: event._id.toString(), event_creator: event_creator_name, event_date: event.date, event_time: event.time, event_location: event.location, event_description: event.description, event_tags: event.tags, event_comments: comments_list, numAttending: event.users_registered.length});
+                if (req.session.prevURL == '/user') {
+                    res.render('shows/event', {title: event.name, user_id: req.session.userId, event_name: event.name, event_id: event._id.toString(), event_creator: event_creator_name, event_date: event.date, event_time: event.time, event_location: event.location, event_description: event.description, event_tags: event.tags, event_comments: comments_list, numAttending: event.users_registered.length});
+                } else if (req.session.prevURL == '/user/regEvents') {
+                    res.render('shows/event', {title: event.name, user_id: req.session.userId, event_name: event.name, event_id: event._id.toString(), event_creator: event_creator_name, event_date: event.date, event_time: event.time, event_location: event.location, event_description: event.description, event_tags: event.tags, event_comments: comments_list, numAttending: event.users_registered.length, myReg: true});
+                } else {
+                    res.render('shows/event', {title: event.name, user_id: req.session.userId, event_name: event.name, event_id: event._id.toString(), event_creator: event_creator_name, event_date: event.date, event_time: event.time, event_location: event.location, event_description: event.description, event_tags: event.tags, event_comments: comments_list, numAttending: event.users_registered.length, home: true});
+                }
             }
         }   
     } catch (error) {

--- a/routes/user.js
+++ b/routes/user.js
@@ -7,6 +7,7 @@ router.get('/', async (req, res) => {
     const pastHosted = await userData.getPastHostedEvents(req.session.userId);
     const pastAttended = await userData.getPastAttendedEvents(req.session.userId);
     const recommendedEvents = await userData.getRecommendedEvents(req.session.userId);
+    req.session.prevURL = '/user';
     res.render('shows/user_profile', {title: "Your Profile", loggedIn: true, name: `${(await userData.get(req.session.userId)).firstName} ${(await userData.get(req.session.userId)).lastName}`, age: `${(await userData.get(req.session.userId)).age}`, email: `${(await userData.get(req.session.userId)).email}`, events_hosted: pastHosted, events_attended: pastAttended, recommended_events: recommendedEvents})
 });
 
@@ -22,7 +23,8 @@ router.get('/delete', async (req, res) => {
 router.get('/regEvents', async (req, res) => {
     const evList = await userData.getRegisteredEvents(req.session.userId);
     const user = await userData.get(req.session.userId);
-    res.render("shows/registeredEvents", {title: "My Registered Events", name: `${user.firstName} ${user.lastName}`, events: evList, loggedIn: true});
+    req.session.prevURL = '/user/regEvents';
+    res.render("shows/registeredEvents", {title: "My Registered Events", name: `${user.firstName} ${user.lastName}`, events: evList, loggedIn: true, myReg: true});
 })
 
 module.exports = router;

--- a/views/shows/event.handlebars
+++ b/views/shows/event.handlebars
@@ -1,7 +1,15 @@
 <h1 id="event-page-header">{{event_name}}</h1>
 
 <div id="top-of-event-page">
-    <a class="btn btn-light" href="/">Back to Home</a>
+    {{#if home}}
+        <a class="btn btn-light" href="/">Back to Home</a>
+    {{else}}
+        {{#if myReg}}
+            <a class="btn btn-light" href="/user/regEvents">Back to My Registered Events</a>
+        {{else}}
+            <a class="btn btn-light" href="/user">Back to User Profile</a>
+        {{/if}}
+    {{/if}}
     <br>
 </div>
 

--- a/views/shows/user_profile.handlebars
+++ b/views/shows/user_profile.handlebars
@@ -30,7 +30,8 @@
 
     <div id="pastEventsHosted">
     <section>
-    <h2 id="allevents-header">Past Events - Hosted</h2>
+    <h2 id="allevents-header">Past Events</h2>
+    <h3>Host</h3>
     <div>
         {{#each events_hosted}}
             <div class="card bg-light text-dark text-center all-events-div">
@@ -46,12 +47,6 @@
                     {{/each}}
                 </div>
             </div>
-            {{!-- <li><a id="event" href="/events/{{_id}}">{{name}} 
-            {{#each tags}}
-                <span class="bade badge-pill badge-info">{{{this}}}</span>
-            {{/each}}
-            </a>
-            </li> --}}
         {{/each}}
     </div>
     </section>
@@ -59,7 +54,8 @@
     <br>
     <div id="pastEventsAttended">
     <section>
-    <h2 id="allevents-header">Past Events - Attended</h2>
+    <h2 id="allevents-header">Past Events</h2>
+    <h3>Attendee</h3>
     <div>
         {{#each events_attended}}
             <div class="card bg-light text-dark text-center all-events-div">
@@ -75,12 +71,6 @@
                     {{/each}}
                 </div>
             </div>
-            {{!-- <li><a id="event" href="/events/{{_id}}">{{name}} 
-            {{#each tags}}
-                <span class="bade badge-pill badge-info">{{{this}}}</span>
-            {{/each}}
-            </a>
-            </li> --}}
         {{/each}}
     </div>
     </section>


### PR DESCRIPTION
… of the site

- When clicking "See Event" on All Events page, there will be a link rendered on the Event/{id} page called "Back to Home" that links back to the All Events page.
- When clicking "See Event" on My Registered Events, there will be a link rendered on the Event/{id} page called "Back to My Registered Events" that links back to the My Registered Events page.
- When clicking "See Event" on the User Profile, there will be a link rendered on the Event/{id} page called "Back to User Profile" that links back to the User Profile page.

This functionality required the use of our AuthCookie where a "prevURL" is stored.  This prevURL is updated to reflect the route that is requesting the GET Events/{id} page, so the site knows where this page should link back to.